### PR TITLE
Redesigend argument distribution

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ slurmtest:
     - dev
     variables:
         PYTEST_ADDOPTS: "--color=yes --tb=short --verbose"
+        GIT_FETCH_EXTRA_FLAGS: --tags
     script:
     - source $HOME/miniconda3/etc/profile.d/conda.sh
     - conda update --yes conda
@@ -26,6 +27,8 @@ pypitest:
     - tags
     tags:
     - deploy
+    variables:
+        GIT_FETCH_EXTRA_FLAGS: --tags
     script:
     - source $HOME/miniconda/etc/profile.d/conda.sh
     - conda update --yes conda
@@ -40,7 +43,7 @@ pypitest:
     - conda create --yes --name piptest python=3.8
     - conda activate piptest
     - conda install --yes pip
-    - pip --no-cache-dir install --extra-index-url https://testpypi.python.org/pypi esi-acme==$version
+    - pip --no-cache-dir install --extra-index-url https://test.pypi.org/simple esi-acme==$version
     - python -c "from acme import ParallelMap"
     - conda deactivate
     - conda remove --yes --name piptest --all
@@ -53,6 +56,8 @@ pypideploy:
     - tags
     tags:
     - deploy
+    variables:
+        GIT_FETCH_EXTRA_FLAGS: --tags
     script:
     - source $HOME/miniconda/etc/profile.d/conda.sh
     - conda update --yes conda

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ pypitest:
     - tarname="$(basename -- $(ls dist/*.tar.gz) .tar.gz)"
     - version=$(sed -e 's/esi-acme-\(.*\)/\1/' <<< "$tarname")
     - twine upload --repository testpypi --config-file=~/.esipypirc dist/*
-    - conda create --yes --name piptest
+    - conda create --yes --name piptest python=3.8
     - conda activate piptest
     - conda install --yes pip
     - pip --no-cache-dir install --extra-index-url https://testpypi.python.org/pypi esi-acme==$version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### FIXED
 - Fixed markdown syntax and URLs
 - Fixed CI pipelines and repaired `h5py` version mismatch in dependencies
+- Pin ACME to Python 3.8.x due to various packages not working properly
+  (yet) in Python 3.9
 
 ## [v0.1a] - 2020-12-30
 ### NEW

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog of ACME
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v0.1b] - 2020-01-15
+### NEW
+- This CHANGELOG file
+
+### CHANGED
+- Modified dependencies to not include Jupyter-related packages
+
+### FIXED
+- Fixed markdown syntax and URLs
+- Fixed CI pipelines and repaired `h5py` version mismatch in dependencies
+
+## [v0.1a] - 2020-12-30
+### NEW
+- Initial ACME pre-release on PyPI
+
+### CHANGED
+- Made ACME GitHub repository public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### CHANGED
+- Changed job submission system: instead of using dask bags, input arguments
+  are directly propagated using dask-client methods. This has the side-effect
+  that the layout of in-memory results changed: instead of returning a nested
+  lists of lists, the user namespace is populated with a plain list of objects
+  (simplifying result handling in the process)
+### DEPRECATED
+- In-memory list-of-list returns are not supported anymore; `ParallelMap` now
+  returns plain (non-nested) lists.
+### FIXED
+- User-provided functions in custom modules are now correctly propagated
+  by inheriting `sys.path` from the parent client
+- Argument distribution is more memory efficient: input arguments are not
+  held in memory by the scheduler and then propagated to workers anymore.
+  Instead, arguments shared by all workers are broadcast to the cluster and
+  referenced by the workers.
 
 ## [v0.1b] - 2020-01-15
 ### NEW

--- a/README.md
+++ b/README.md
@@ -119,9 +119,7 @@ This is possible but not recommended.
 
 ```python
 with ParallelMap(f, [2, 4, 6, 8], 4, write_worker_results=False) as pmap:
-  results = pmap.compute()
-
-out = np.array([xi[0][0] for xi in results])
+  results = pmap.compute() # returns a list of outputs
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and released free of charge under the
 ACME relies on the concurrent processing library [Dask](https://docs.dask.org/en/latest/>)
 and was primarily designed to facilitate the use of [SLURM](https://slurm.schedmd.com/documentation.html)
 on the ESI HPC cluster. However, local multi-processing hardware (i.e., multi-core CPUs)
-is fully supported as well. ACME is based on the parallelization engine used in [SyNCoPy](http://www.syncopy.org/>) and
+is fully supported as well. ACME is based on the parallelization engine used in [SyNCoPy](http://www.syncopy.org/) and
 is itself part of the SyNCoPy package.
 
 ## Installation

--- a/acme.yml
+++ b/acme.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   # acme runtime requirements
-  - python>=3.7
+  - python > =3.7, < 3.9
   - pip
   - numpy >= 1.0, < 2.0
   - dask >= 2.25, < 2.26

--- a/acme/__init__.py
+++ b/acme/__init__.py
@@ -12,7 +12,7 @@ from importlib.metadata import version, PackageNotFoundError
 
 # Get package version: either via meta-information from egg or via latest git commit
 try:
-    __version__ = version(__name__)
+    __version__ = version("esi-acme")
 except PackageNotFoundError:
     proc = subprocess.Popen("git describe --always",
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -29,13 +29,6 @@ except PackageNotFoundError:
             warnings.showwarning(msg, ImportWarning, __file__, inspect.currentframe().f_lineno)
             out = "-999"
     __version__ = out.rstrip("\n")
-
-# # Check if we're being imported by a parallel worker process: FIXME - do we need this?
-# try:
-#     dd.get_worker()
-#     __worker__ = True
-# except ValueError:
-#     __worker__ = False
 
 # Import local modules
 from . import frontend, backend, shared, dask_helpers

--- a/acme/backend.py
+++ b/acme/backend.py
@@ -15,9 +15,9 @@ import h5py
 import glob
 import tqdm
 import functools
+import dask
 import dask.distributed as dd
 import dask_jobqueue as dj
-import dask.bag as db
 import numpy as np
 
 # Local imports
@@ -106,27 +106,25 @@ class ACMEdaemon(object):
         except Exception as exc:
             raise exc
 
-        # # Ensure all elements of `argv` are list-like with length `n_calls` or generators
-        # msg = "{} `argv` has to be a list with list-like elements of length {}"
-        # if not isinstance(argv, (list, tuple)):
-        #     raise TypeError(msg.format(self.msgName, n_calls))
-        # try:
-        #     validArgv = all(len(arg) == n_calls if hasattr(arg, "__len__") \
-        #         else inspect.isgenerator(arg) for arg in argv)
-        # except TypeError:
-        #     raise TypeError(msg.format(self.msgName, n_calls))
-        # if not validArgv:
-        #     raise ValueError(msg.format(self.msgName, n_calls))
+        # Ensure all elements of `argv` are list-like with lengths `n_calls` or 1
+        msg = "{} `argv` has to be a list with list-like elements of length 1 or {}"
+        if not isinstance(argv, (list, tuple)):
+            raise TypeError(msg.format(self.msgName, n_calls))
+        try:
+            validArgv = all(len(arg) == n_calls or len(arg) == 1 for arg in argv)
+        except TypeError:
+            raise TypeError(msg.format(self.msgName, n_calls))
+        if not validArgv:
+            raise ValueError(msg.format(self.msgName, n_calls))
 
-        # # Ensure all keys of `kwargv` have length `n_calls` or are generators
-        # msg = "{} `kwargv` has to be a dictionary with list-like elements of length {}"
-        # try:
-        #     validKwargv = all(len(value) == n_calls if hasattr(value, "__len__") \
-        #         else inspect.isgenerator(value) for value in kwargv.values())
-        # except TypeError:
-        #     raise TypeError(msg.format(self.msgName, n_calls))
-        # if not validKwargv:
-        #     raise ValueError(msg.format(self.msgName, n_calls))
+        # Ensure all values of `kwargv` are list-like with lengths `n_calls` or 1
+        msg = "{} `kwargv` has to be a dictionary with list-like elements of length {}"
+        try:
+            validKwargv = all(len(value) == n_calls or len(value) == 1 for value in kwargv.values())
+        except TypeError:
+            raise TypeError(msg.format(self.msgName, n_calls))
+        if not validKwargv:
+            raise ValueError(msg.format(self.msgName, n_calls))
 
         # Basal sanity checks have passed, keep the provided input signature
         self.func = func
@@ -180,7 +178,7 @@ class ACMEdaemon(object):
             # accept "anonymous" `**kwargs`, don't save anything but return stuff
             if self.kwargv.get("taskID") is None:
                 # and "kwargs" not in inspect.signature(self.func).parameters.keys():
-                msg = "`write_worker_results` is `False` and `taskID` is not a keyword argument of {}." +\
+                msg = "`write_worker_results` is `False` and `taskID` is not a keyword argument of {}. " +\
                     "Results will be collected in memory by caller - this might be slow and can lead " +\
                     "to excessive memory consumption. "
                 self.log.warning(msg.format(self.func.__name__))
@@ -317,17 +315,23 @@ class ACMEdaemon(object):
             sys.path = list(syspath)
         self.client.register_worker_callbacks(setup=functools.partial(init_acme, syspath=sys.path))
 
-
+        # Format positional arguments for worker-distribution: broadcast all
+        # inputs that are used by all workers and create a list of references
+        # to this (single!) future on the cluster for submission
         for ak, arg in enumerate(self.argv):
             if len(arg) == 1:
                 ftArg = self.client.scatter(arg, broadcast=True)[0]
                 self.argv[ak] = [ftArg] * self.n_calls
 
+        # Same as above but for keyword-arguments
         for name, value in self.kwargv.items():
             if len(value) == 1:
                 ftVal = self.client.scatter(value, broadcast=True)[0]
                 self.kwargv[name] = [ftVal] * self.n_calls
 
+        # Re-format keyword arguments to be usable with single-to-many arg submission.
+        # Idea: with `self.n_calls = 3` and ``self.kwargv = {'a': [5, 5, 5], 'b': [6, 6, 6]}``
+        # then ``kwargList = [{'a': 5, 'b': 6}, {'a': 5, 'b': 6}, {'a': 5, 'b': 6}]``
         kwargList = []
         kwargKeys = self.kwargv.keys()
         kwargVals = list(self.kwargv.values())
@@ -337,17 +341,12 @@ class ACMEdaemon(object):
                 kwDict[key] = kwargVals[kc][nc]
             kwargList.append(kwDict)
 
-        futures = [self.client.submit(self.acme_func, *args, **kwargs) for args, kwargs in zip(zip(*self.argv), kwargList)]
-
-        # # Now, start to actually do something: map pos./kw. args onto (wrapped) user function
-        # results = firstArg.map(self.acme_func, *otherArgs, **kwargBags)
-
-        # print('after results')
-
         # In case a debugging run is performed, use the single-threaded scheduler and return
         if debug:
-            values = results.compute(scheduler="single-threaded")
-            return values
+            with dask.config.set(scheduler='single-threaded'):
+                values = self.client.gather([self.client.submit(self.acme_func, *args, **kwargs) \
+                    for args, kwargs in zip(zip(*self.argv), kwargList)])
+                return values
 
         # Depending on the used dask cluster object, point to respective log info
         if isinstance(self.client.cluster, dj.SLURMCluster):
@@ -361,8 +360,9 @@ class ACMEdaemon(object):
         msg = "Log information available at {}"
         self.log.info(msg.format(logDir))
 
-        # # Persist task graph to cluster and keep track of futures
-        # futures = self.client.futures_of(results.persist())
+        # Submit `self.n_calls` function calls to the cluster
+        futures = [self.client.submit(self.acme_func, *args, **kwargs) \
+            for args, kwargs in zip(zip(*self.argv), kwargList)]
 
         # Set up progress bar: the while loop ensures all futures are executed
         totalTasks = len(futures)

--- a/acme/backend.py
+++ b/acme/backend.py
@@ -317,13 +317,21 @@ class ACMEdaemon(object):
             sys.path = list(syspath)
         self.client.register_worker_callbacks(setup=functools.partial(init_acme, syspath=sys.path))
 
+        print('b4 bag init')
+
         # Convert positional/keyword arg lists to dask bags
         firstArg = db.from_sequence(self.argv[0], npartitions=self.n_calls)
         otherArgs = [db.from_sequence(arg, npartitions=self.n_calls) for arg in self.argv[1:] if len(self.argv) > 1]
         kwargBags = {key:db.from_sequence(value, npartitions=self.n_calls) for key, value in self.kwargv.items()}
 
+        print('after bag init')
+
+        print('b4 results')
+
         # Now, start to actually do something: map pos./kw. args onto (wrapped) user function
         results = firstArg.map(self.acme_func, *otherArgs, **kwargBags)
+
+        print('after results')
 
         # In case a debugging run is performed, use the single-threaded scheduler and return
         if debug:

--- a/acme/frontend.py
+++ b/acme/frontend.py
@@ -527,6 +527,8 @@ class ParallelMap(object):
                 raise ValueError(msg.format(self.msgName, n_inputs))
         self.n_inputs = int(n_inputs)
 
+        gen = lambda obj: (obj for _ in range(self.n_inputs))
+
         # Anything that does not contain `n_input` elements is duplicated for
         # distribution across workers, e.g., ``args = [3, [0, 1, 1]]`` then
         # ``self.argv = [[3, 3, 3], [0, 1, 1]]``
@@ -540,7 +542,7 @@ class ParallelMap(object):
                     continue
                 else:
                     arg = da.from_array(arg, chunks=arg.shape)
-            self.argv[ak] = (arg for _ in range(self.n_inputs))
+            self.argv[ak] = gen(arg)
 
         # Same for keyword arguments with the caveat that default values have to
         # be taken into account (cf. above)
@@ -555,7 +557,7 @@ class ParallelMap(object):
                     continue
                 else:
                     value = da.from_array(value, chunks=value.shape)
-            self.kwargv[name] = (value for _ in range(self.n_inputs))
+            self.kwargv[name] = gen(value)
 
         # Finally, attach user-provided function to class instance
         self.func = func

--- a/acme/frontend.py
+++ b/acme/frontend.py
@@ -122,8 +122,7 @@ class ParallelMap(object):
         results : list
             If `write_worker_results` is `True`, `results` is a list of HDF5 file-names
             containing computed results. If `write_worker_results` is `False`,
-            results is a list of lists comprising the actual return values of
-            `func`.
+            results is a list comprising the actual return values of `func`.
 
         Examples
         --------
@@ -181,14 +180,10 @@ class ParallelMap(object):
             with ParallelMap(f, [2, 4, 6, 8], 4, write_worker_results=False) as pmap:
                 results = pmap.compute()
 
-        Now `results` is a list of lists:
+        Now `results` is a list of integers:
 
         >>> results
-        [[18], [24], [30], [36]]
-
-        To extract values into a NumPy array one may use
-
-        >>> out = np.array([xi[0][0] for xi in results])
+        [18, 24, 30, 36]
 
         Next, suppose `f` has to be evaluated for the same values of `x` (again
         2, 4, 6 and 8), but `y` is not a number but a NumPy array:
@@ -215,10 +210,10 @@ class ParallelMap(object):
         yielding
 
         >>> results
-        [[array([18., 18., 18.])],
-         [array([24., 24., 24.])],
-         [array([30., 30., 30.])],
-         [array([36., 36., 36.])]]
+        [array([18., 18., 18.]),
+         array([24., 24., 24.]),
+         array([30., 30., 30.]),
+         array([36., 36., 36.])]
 
         Now suppose `f` needs to be evaluated for fixed values of `x` and `y`
         with `z` varying randomly 500 times between 1 and 10. Since `f` is a
@@ -527,9 +522,7 @@ class ParallelMap(object):
                 raise ValueError(msg.format(self.msgName, n_inputs))
         self.n_inputs = int(n_inputs)
 
-        # Anything that does not contain `n_input` elements is duplicated for
-        # distribution across workers, e.g., ``args = [3, [0, 1, 1]]`` then
-        # ``self.argv = [[3, 3, 3], [0, 1, 1]]``
+        # Anything that does not contain `n_input` elements is converted to a one-element list
         self.argv = list(args)
         for ak, arg in enumerate(args):
             if isinstance(arg, (list, tuple)):

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ zip_safe = False
 
 [options.data_files]
 acme =
+    CHANGELOG.md
     conda2pip.py
     LICENSE
     README.md


### PR DESCRIPTION
Use dask's client methods instead of bags to (a) broadcast shared variables to a cluster of workers and (b) distribute worker-specific arguments. 